### PR TITLE
Skip failed builds and do not abort the loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Bitrise Start Build
 
 Starts the given workflows in the same app.
+The only difference from the original version, is that we do not abort the iteration of workflows, in case of an error.
+Main use-case is e.g. one of the workflows has a typo, or was removed, but is still referenced in this step. 
+So we want to fail only this workflow, and continue the execution of others  
 
 ## How to use this Step
 

--- a/main.go
+++ b/main.go
@@ -63,9 +63,10 @@ func main() {
 		}
 		if startedBuild.BuildSlug == "" {
 			log.Warnf("Build was not started. This could mean that manual build approval is enabled for this project and it's blocking this step from starting builds.")
+		} else {
+			buildSlugs = append(buildSlugs, startedBuild.BuildSlug)
+			log.Printf("- %s started (https://app.bitrise.io/build/%s)", startedBuild.TriggeredWorkflow, startedBuild.BuildSlug)
 		}
-		buildSlugs = append(buildSlugs, startedBuild.BuildSlug)
-		log.Printf("- %s started (https://app.bitrise.io/build/%s)", startedBuild.TriggeredWorkflow, startedBuild.BuildSlug)
 	}
 
 	if err := tools.ExportEnvironmentWithEnvman(envBuildSlugs, strings.Join(buildSlugs, "\n")); err != nil {

--- a/main.go
+++ b/main.go
@@ -59,10 +59,10 @@ func main() {
 		wf = strings.TrimSpace(wf)
 		startedBuild, err := app.StartBuild(wf, build.OriginalBuildParams, cfg.BuildNumber, environments)
 		if err != nil {
-			failf("Failed to start build, error: %s", err)
+			log.Warnf("Failed to start build, error: %s", err)
 		}
 		if startedBuild.BuildSlug == "" {
-			failf("Build was not started. This could mean that manual build approval is enabled for this project and it's blocking this step from starting builds.")
+			log.Warnf("Build was not started. This could mean that manual build approval is enabled for this project and it's blocking this step from starting builds.")
 		}
 		buildSlugs = append(buildSlugs, startedBuild.BuildSlug)
 		log.Printf("- %s started (https://app.bitrise.io/build/%s)", startedBuild.TriggeredWorkflow, startedBuild.BuildSlug)


### PR DESCRIPTION
Main use-case is e.g. one of the workflows has a typo, or was removed, but is still referenced in this step. 
So we want to fail only this workflow, and continue the execution of others